### PR TITLE
Remove duplicate ci lint and test jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,41 +7,11 @@ on:
       - main
 
 jobs:
-  go-lint:
+  integration-tests:
+    if: false # Remove this line when enabling integration tests.
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.24.x
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Run linters
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: latest
-          args: --timeout=3m
-  go-test:
-    strategy:
-      matrix:
-        go-version: [1.24.x]
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - name: Install Go
-        if: success()
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: go tests
-        run: (set -o pipefail && go test -v -covermode=count -json ./... | tee test.json)
-      - name: annotate go tests
-        if: always()
-        uses: guyarb/golang-test-annotations@v0.5.1
-        with:
-          test-results: test.json
+      - run: echo "Integration tests are disabled."
   # test:
   #   runs-on: ubuntu-latest
   #   services:


### PR DESCRIPTION
## Why

The shared managed `verify.yaml` workflow already runs the Go lint and test checks for this repo. Keeping the same checks in `.github/workflows/ci.yaml` duplicates CI work and can create extra noise.

## What this changes

Removes the active `go-lint` and `go-test` jobs from `.github/workflows/ci.yaml`. The workflow keeps a disabled `integration-tests` placeholder and the existing commented FreeIPA scaffold so future integration tests can be added in the same file when needed.

## Test plan

- `yq . .github/workflows/ci.yaml >/dev/null`
- Ruby YAML parse
- `git diff --check`